### PR TITLE
Made togglechannel less hardcoded

### DIFF
--- a/addons/extras.py
+++ b/addons/extras.py
@@ -13,6 +13,7 @@ class Extras:
     """
     def __init__(self, bot):
         self.bot = bot
+        self.toggablechannels = {'nsfw':'nsfw'}
         print('Addon "{}" loaded'.format(self.__class__.__name__))
 
     prune_key = "nokey"
@@ -136,17 +137,17 @@ class Extras:
         await self.bot.say("Done!")
 
     @commands.command(pass_context=True, hidden=True)
-    async def togglechannel(self, ctx, channelname):
+    async def togglechannel(self, ctx, channelname:str):
         """Enable or disable access to specific channels."""
         author = ctx.message.author
         await self.bot.delete_message(ctx.message)
-        if channelname == "nsfw":
-            if self.bot.nsfw_role in author.roles:
-                await self.bot.remove_roles(author, self.bot.nsfw_role)
-                await self.bot.send_message(author, "Access to #nsfw removed.")
+        if channelname.lower() in self.toggablechannels:
+            if discord.utils.get(server.roles, name=self.toggablechannels[channelname.lower()]) in author.roles:
+                await self.bot.remove_roles(author,discord.utils.get(server.roles, name=self.toggablechannels[channelname.lower()]))
+                await self.bot.send_message(author, "Access to #{0} removed.".format(channelname))
             else:
-                await self.bot.add_roles(author, self.bot.nsfw_role)
-                await self.bot.send_message(author, "Access to #nsfw granted.")
+                await self.bot.add_roles(author, discord.utils.get(server.roles, name=self.toggablechannels[channelname.lower()]))
+                await self.bot.send_message(author, "Access to #{0} granted.".format(channelname))
         else:
             await self.bot.send_message(author, "{} is not a valid toggleable channel.".format(channelname))
 


### PR DESCRIPTION
The way it works is that is searches the channel trying to be toggles in a dict and if it is there it gets the value behind it, which in all cases should be the role name.